### PR TITLE
Fixed my problem with downloading shorts

### DIFF
--- a/tubepy/lang.py
+++ b/tubepy/lang.py
@@ -163,7 +163,7 @@ async def file_verification(youtube_url) -> bool:
     validatd_url = validate_youtube_url(youtube_url)
     status = await search_file_Availability(youtube_url) if validatd_url else None
 
-    if status == 200:
+    if status == 200 or 302:
         return True
     return False
 


### PR DESCRIPTION
I added 'or 302' in the file_verification function in lang.py. After I did this, I was able to download this short `https://www.youtube.com/shorts/FJX5R0PYt8M`. I also tested it with this url `https://youtu.be/8RcP7BmUKaA` and it worked out.

This fixes issue #30 